### PR TITLE
Add TemplatePageFilter to filter by TemplatePathInfo

### DIFF
--- a/commons/changes.xml
+++ b/commons/changes.xml
@@ -22,7 +22,11 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
-
+    <release version="1.0.6" date="unreleased">
+      <action type="add" dev="amuthmann">
+        Add TemplatePageFilter to filter by TemplatePathInfo
+      </action>
+    </release>
     <release version="1.0.4" date="2017-11-28">
       <action type="update" dev="sseifert">
         Mark RunMode class as deprecated because it violates best practises.

--- a/commons/src/main/java/io/wcm/wcm/commons/util/TemplatePageFilter.java
+++ b/commons/src/main/java/io/wcm/wcm/commons/util/TemplatePageFilter.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2018 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.commons.util;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.day.cq.wcm.api.NameConstants;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageFilter;
+
+/**
+ * Extension of {@link PageFilter} allowing usage of {@link TemplatePathInfo}
+ *
+ */
+public class TemplatePageFilter extends PageFilter {
+
+  private final Set<String> allowedTemplates;
+
+  /**
+   * @param templatePath
+   */
+  public TemplatePageFilter(TemplatePathInfo... templatePath) {
+    this(false, false, templatePath);
+  }
+
+  /**
+   * @param includeInvalid if <code>true</code> invalid pages are included.
+   * @param includeHidden if <code>true</code> hidden pages are included.
+   * @param templatePaths The resource types to be included
+   */
+  public TemplatePageFilter(boolean includeInvalid, boolean includeHidden, TemplatePathInfo... templatePaths) {
+    super(includeInvalid, includeHidden);
+    allowedTemplates = Arrays.stream(templatePaths).map(TemplatePathInfo::getTemplatePath).collect(Collectors.toSet());
+  }
+
+  @Override
+  public boolean includes(Page page) {
+    return super.includes(page)
+        && allowedTemplates.contains(page.getProperties().get(NameConstants.PN_TEMPLATE, String.class));
+  }
+
+}

--- a/commons/src/main/java/io/wcm/wcm/commons/util/package-info.java
+++ b/commons/src/main/java/io/wcm/wcm/commons/util/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Miscellaneous WCM helper classes.
  */
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package io.wcm.wcm.commons.util;

--- a/commons/src/test/java/io/wcm/wcm/commons/testcontext/AppTemplate.java
+++ b/commons/src/test/java/io/wcm/wcm/commons/testcontext/AppTemplate.java
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2018 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.commons.testcontext;
+
+import io.wcm.wcm.commons.util.Template;
+import io.wcm.wcm.commons.util.TemplatePathInfo;
+
+/**
+ * TemplatePathInfo implementation for Tests
+ */
+public enum AppTemplate implements TemplatePathInfo {
+
+  TEMPLATE_1("/apps/app1/templates/t1"),
+  TEMPLATE_2("/apps/app1/templates/t2"),
+  TEMPLATE_3("/apps/app1/templates/t3");
+
+  private final String templatePath;
+  private final String resourceType;
+
+  AppTemplate(String templatePath) {
+    this.templatePath = templatePath;
+    this.resourceType = Template.getResourceTypeFromTemplatePath(templatePath);
+  }
+
+  @Override
+  public String getTemplatePath() {
+    return templatePath;
+  }
+
+  @Override
+  public String getResourceType() {
+    return resourceType;
+  }
+
+}

--- a/commons/src/test/java/io/wcm/wcm/commons/util/TemplatePageFilterTest.java
+++ b/commons/src/test/java/io/wcm/wcm/commons/util/TemplatePageFilterTest.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2018 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.commons.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.day.cq.wcm.api.NameConstants;
+import com.day.cq.wcm.api.Page;
+
+import static org.junit.Assert.assertTrue;
+
+import io.wcm.sling.commons.resource.ImmutableValueMap;
+import io.wcm.wcm.commons.testcontext.AppTemplate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TemplatePageFilterTest {
+
+  @Mock
+  private Page pageTemplate1;
+
+  @Mock
+  private Page pageTemplate2;
+
+  @Mock
+  private Page pageTemplate3;
+
+  @Before
+  public void setUp() {
+    when(pageTemplate1.getProperties()).thenReturn(ImmutableValueMap.of(NameConstants.PN_TEMPLATE, AppTemplate.TEMPLATE_1.getTemplatePath()));
+    when(pageTemplate2.getProperties()).thenReturn(ImmutableValueMap.of(NameConstants.PN_TEMPLATE, AppTemplate.TEMPLATE_2.getTemplatePath()));
+    when(pageTemplate3.getProperties()).thenReturn(ImmutableValueMap.of(NameConstants.PN_TEMPLATE, AppTemplate.TEMPLATE_3.getTemplatePath()));
+  }
+
+  @Test
+  public void testSingleMatchingTemplates() {
+    TemplatePageFilter pageFilter = new TemplatePageFilter(true, true, AppTemplate.TEMPLATE_3);
+    assertFalse(pageFilter.includes(pageTemplate1));
+    assertFalse(pageFilter.includes(pageTemplate2));
+    assertTrue(pageFilter.includes(pageTemplate3));
+  }
+
+  @Test
+  public void testMultipleTemplates() {
+    TemplatePageFilter pageFilter = new TemplatePageFilter(true, true, AppTemplate.TEMPLATE_1, AppTemplate.TEMPLATE_2);
+    assertTrue(pageFilter.includes(pageTemplate1));
+    assertTrue(pageFilter.includes(pageTemplate2));
+    assertFalse(pageFilter.includes(pageTemplate3));
+  }
+}

--- a/commons/src/test/java/io/wcm/wcm/commons/util/TemplateTest.java
+++ b/commons/src/test/java/io/wcm/wcm/commons/util/TemplateTest.java
@@ -35,6 +35,7 @@ import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.Page;
 
 import io.wcm.sling.commons.resource.ImmutableValueMap;
+import io.wcm.wcm.commons.testcontext.AppTemplate;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TemplateTest {
@@ -104,34 +105,4 @@ public class TemplateTest {
     assertEquals(AppTemplate.TEMPLATE_1, Template.forPage(page, AppTemplate.class));
     assertNull(Template.forPage(null, AppTemplate.class));
   }
-
-
-  private enum AppTemplate implements TemplatePathInfo {
-
-    TEMPLATE_1("/apps/app1/templates/t1"),
-
-    TEMPLATE_2("/apps/app1/templates/t2"),
-
-    TEMPLATE_3("/apps/app1/templates/t3");
-
-    private final String templatePath;
-    private final String resourceType;
-
-    AppTemplate(String templatePath) {
-      this.templatePath = templatePath;
-      this.resourceType = Template.getResourceTypeFromTemplatePath(templatePath);
-    }
-
-    @Override
-    public String getTemplatePath() {
-      return templatePath;
-    }
-
-    @Override
-    public String getResourceType() {
-      return resourceType;
-    }
-
-  }
-
 }


### PR DESCRIPTION
The AEM Page's list Children [method](https://helpx.adobe.com/experience-manager/6-3/sites/developing/using/reference-materials/javadoc/com/day/cq/wcm/api/Page.html#listChildren(com.day.cq.commons.Filter)) allows the usage of a filter to select only a limited set of childpages. This becomes handy when combined with the TemplatePathInfo Interface.