### PR TITLE
ComponentPropertyResolver: Consider overridden resource type via data-sly-resource @ resourceType=x/y/z 

### DIFF
--- a/commons/changes.xml
+++ b/commons/changes.xml
@@ -23,6 +23,14 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.6.1" date="not released">
+      <action type="fix" dev="sseifert">
+        ComponentPropertyResolver: When using data-sly-resource=... @ resourceType=x/y/z the component x/y/z
+        is now considered for looking up component level properties. In previous versions the original resource type
+        was used if present.
+      </action>
+    </release>
+
     <release version="1.6.0" date="2020-01-30">
       <action type="update" dev="sseifert"><![CDATA[
         ComponentPropertyResolver: Introduce ComponentPropertyResolverFactory to ensure local component resources can be resolved properly on publish instances.<br/>

--- a/commons/src/main/java/io/wcm/wcm/commons/component/ComponentPropertyResolver.java
+++ b/commons/src/main/java/io/wcm/wcm/commons/component/ComponentPropertyResolver.java
@@ -19,8 +19,6 @@
  */
 package io.wcm.wcm.commons.component;
 
-import static org.apache.sling.api.resource.ResourceResolver.PROPERTY_RESOURCE_TYPE;
-
 import java.util.Collection;
 
 import org.apache.commons.lang3.StringUtils;
@@ -35,6 +33,7 @@ import org.osgi.annotation.versioning.ProviderType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.components.Component;
@@ -195,11 +194,24 @@ public final class ComponentPropertyResolver implements AutoCloseable {
     if (resource == null) {
       return null;
     }
-    String resourceType = resource.getValueMap().get(PROPERTY_RESOURCE_TYPE, String.class);
-    if (resourceType != null) {
+    if (hasRealResourceType(resource)) {
       return resource;
     }
     return getResourceWithResourceType(resource.getParent());
+  }
+
+  private static boolean hasRealResourceType(@NotNull Resource resource) {
+    String resourceType = resource.getResourceType();
+    if(resourceType==null) {
+      return false;
+    }
+
+    // ignore resource types equal to the resource's jcr:primaryType 
+    if(resourceType.equals(resource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE,String.class))) {
+      return false;
+    }
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
When using `data-sly-resource=... @ resourceType='x/y/z'` the component `x/y/z` is
currently not considered for looking up component level properties, if the actual
resource has a non null sling:resourceType in it's ValueMap.

Reason: When overriding the resource type via HTL then we're dealing with a [SlingRequestDispatcher's ResourceWrapper](https://github.com/apache/sling-org-apache-sling-engine/blob/master/src/main/java/org/apache/sling/engine/impl/request/SlingRequestDispatcher.java#L263) instance where only getResourceType() returns x/y/z . Currently [we're looking at](https://github.com/wcm-io/wcm-io-wcm/blob/9da0e1959768f68487a43b1395426d23656b9799/commons/src/main/java/io/wcm/wcm/commons/component/ComponentPropertyResolver.java#L198) `getValueMap().get("sling:resourceType")` - intended to not misinterpret things like `nt:unstructured`. In my case this will return the original resource type and thus unexpected component property values may be looked up by the ComponentPropertyResolver.

I came up with a possible fix where we do use `Resource.getResourceType()` but compare any non null value with the resource's `jcr:primaryType` value. If they match we can ignore the resource type. So in my case `x/y/z` will be considered and I end up with component level properties defined in `x/y/z`.

