### PR TITLE
ComponentPropertyResolver: Respect overriden resource type from request

### DIFF
--- a/commons/changes.xml
+++ b/commons/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.6.2" date="not released">
+      <action type="fix" dev="sseifert">
+        ComponentPropertyResolver: Respect overriden resource type from request when checking for resource type-based property inheritance.
+      </action>
+    </release>
+
     <release version="1.6.0" date="2020-01-30">
       <action type="update" dev="sseifert"><![CDATA[
         ComponentPropertyResolver: Introduce ComponentPropertyResolverFactory to ensure local component resources can be resolved properly on publish instances.<br/>

--- a/commons/src/main/java/io/wcm/wcm/commons/component/ComponentPropertyResolver.java
+++ b/commons/src/main/java/io/wcm/wcm/commons/component/ComponentPropertyResolver.java
@@ -19,8 +19,6 @@
  */
 package io.wcm.wcm.commons.component;
 
-import static org.apache.sling.api.resource.ResourceResolver.PROPERTY_RESOURCE_TYPE;
-
 import java.util.Collection;
 
 import org.apache.commons.lang3.StringUtils;
@@ -191,15 +189,26 @@ public final class ComponentPropertyResolver implements AutoCloseable {
     return StringUtils.isNotEmpty(resource.getResourceType());
   }
 
+  @SuppressWarnings("null")
   private static @Nullable Resource getResourceWithResourceType(@Nullable Resource resource) {
     if (resource == null) {
       return null;
     }
-    String resourceType = resource.getValueMap().get(PROPERTY_RESOURCE_TYPE, String.class);
-    if (resourceType != null) {
+    String resourceType = resource.getResourceType();
+    if (resourceType != null && isPathBasedResourceType(resourceType)) {
       return resource;
     }
     return getResourceWithResourceType(resource.getParent());
+  }
+
+  /**
+   * Checks if the resource type is a path pointing to a component resource in the repository
+   * (where we can lookup properties to inherit from).
+   * @param resourceType Resource type
+   * @return true for path-based resource types
+   */
+  private static boolean isPathBasedResourceType(@NotNull String resourceType) {
+    return StringUtils.contains(resourceType, "/");
   }
 
   /**

--- a/commons/src/test/java/io/wcm/wcm/commons/component/AbstractComponentPropertyResolverTest.java
+++ b/commons/src/test/java/io/wcm/wcm/commons/component/AbstractComponentPropertyResolverTest.java
@@ -69,6 +69,23 @@ abstract class AbstractComponentPropertyResolverTest {
   }
 
   @Test
+  void testResourceWithComponent_ForceResourceType() {
+    Resource component1 = context.create().resource("/apps/app1/components/comp1",
+        "prop1", "value1");
+    Resource component2 = context.create().resource("/apps/app1/components/comp2",
+        "prop1", "value2");
+    Resource resource = context.create().resource("/content/r1",
+        PROPERTY_RESOURCE_TYPE, component1.getPath());
+
+    TypeOverwritingResourceWrapper resourceWrapper = new TypeOverwritingResourceWrapper(resource,
+        component2.getPath());
+
+    ComponentPropertyResolver underTest = getComponentPropertyResolver(resourceWrapper);
+    assertEquals("value2", underTest.get("prop1", String.class));
+    assertEquals("value2", underTest.get("prop1", "def"));
+  }
+
+  @Test
   void testResourceWithComponent_ChildResourceProperty() {
     Resource component = context.create().resource("/apps/app1/components/comp1",
         "prop1", "value1");
@@ -97,6 +114,26 @@ abstract class AbstractComponentPropertyResolverTest {
     ComponentPropertyResolver underTest = getComponentPropertyResolver(subresource2, true);
     assertEquals("value1", underTest.get("prop1", String.class));
     assertEquals("value1", underTest.get("prop1", "def"));
+  }
+
+  @Test
+  void testResourceWithComponent_EnsureResourceType_ForceResourceType() {
+    Resource component1 = context.create().resource("/apps/app1/components/comp1",
+        "prop1", "value1");
+    Resource component2 = context.create().resource("/apps/app1/components/comp2",
+        "prop1", "value2");
+    Resource resource = context.create().resource("/content/r1",
+        PROPERTY_RESOURCE_TYPE, component1.getPath());
+    Resource subresource1 = context.create().resource(resource, "subresource1",
+        JcrConstants.JCR_PRIMARYTYPE, JcrConstants.NT_UNSTRUCTURED);
+    Resource subresource2 = context.create().resource(subresource1, "subresource2");
+
+    TypeOverwritingResourceWrapper resourceWrapper = new TypeOverwritingResourceWrapper(subresource2,
+        component2.getPath());
+
+    ComponentPropertyResolver underTest = getComponentPropertyResolver(resourceWrapper, true);
+    assertEquals("value2", underTest.get("prop1", String.class));
+    assertEquals("value2", underTest.get("prop1", "def"));
   }
 
   @Test

--- a/commons/src/test/java/io/wcm/wcm/commons/component/TypeOverwritingResourceWrapper.java
+++ b/commons/src/test/java/io/wcm/wcm/commons/component/TypeOverwritingResourceWrapper.java
@@ -1,0 +1,56 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2020 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.commons.component;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceWrapper;
+
+/**
+ * Simulate behavior of SlingRequestDispatcher$TypeOverwritingResourceWrapper
+ */
+class TypeOverwritingResourceWrapper extends ResourceWrapper {
+
+  private final String resourceType;
+
+  TypeOverwritingResourceWrapper(Resource delegatee, String resourceType) {
+    super(delegatee);
+    this.resourceType = resourceType;
+  }
+
+  @Override
+  public String getResourceType() {
+    return resourceType;
+  }
+
+  /**
+   * Overwrite this here because the wrapped resource will return null as
+   * a super type instead of the resource type overwritten here
+   */
+  @Override
+  public String getResourceSuperType() {
+    return null;
+  }
+
+  @Override
+  public boolean isResourceType(final String value) {
+    return this.getResourceResolver().isResourceType(this, value);
+  }
+
+}


### PR DESCRIPTION
when checking for resource type-based property inheritance.

alternative implementation to #10 