### PR TITLE
Configurable SiteMap Servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
   <modules>
     <module>parent</module>
     <module>commons</module>
+    <module>utils</module>
     <module>ui/granite</module>
     <module>ui/extjs</module>
     <module>ui/clientlibs</module>

--- a/utils/changes.xml
+++ b/utils/changes.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  wcm.io
+  %%
+  Copyright (C) 2014 wcm.io
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
+    xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
+  <body>
+
+    <release version="0.1.0" date="not-released-yet">
+      <action type="add" dev="deveth0">
+        Add SiteMap Servlet
+      </action>
+    </release>
+
+  </body>
+</document>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -105,6 +105,24 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.testing.wcm-io-mock.caconfig</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.testing.wcm-io-mock.wcm</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.caconfig-mock-plugin</artifactId>
+      <version>1.3.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.logging-mock</artifactId>
       <version>2.0.0</version>
@@ -134,6 +152,8 @@
       <artifactId>geronimo-annotation_1.3_spec</artifactId>
       <scope>provided</scope>
     </dependency>
+
+
 
   </dependencies>
 
@@ -170,6 +190,14 @@
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>9</source>
+          <target>9</target>
         </configuration>
       </plugin>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  wcm.io
+  %%
+  Copyright (C) 2014 wcm.io
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.wcm</groupId>
+    <artifactId>io.wcm.wcm.parent</artifactId>
+    <version>1.4.1-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>io.wcm.wcm.utils</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>WCM Utils</name>
+  <description>Utils for wcm.io.</description>
+  <url>${site.url}/${site.url.module.prefix}/</url>
+
+  <scm>
+    <connection>scm:git:https://github.com/wcm-io/wcm-io-wcm.git</connection>
+    <developerConnection>scm:git:https://github.com/wcm-io/wcm-io-wcm.git</developerConnection>
+    <url>https://github.com/wcm-io/wcm-io-wcm</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <properties>
+    <site.url.module.prefix>wcm/commons</site.url.module.prefix>
+
+    <!-- Enable reproducible builds -->
+    <project.build.outputTimestamp>${timestamp}</project.build.outputTimestamp>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.sling.models</artifactId>
+      <version>1.6.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.sling.commons</artifactId>
+      <version>1.4.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.url</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
+      <version>4.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.logging-mock</artifactId>
+      <version>2.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.testing.wcm-io-mock.sling</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- For build compatibility with Java 11 -->
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-annotation_1.3_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+
+    <plugins>
+
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <configuration>
+          <bnd>
+            Sling-Initial-Content: SLING-INF/app-root;overwrite:=true;ignoreImportProviders:=xml;path:=/apps/wcm-io/wcm/utils
+            Sling-Namespaces: wcmio=http://wcm.io/ns
+
+            <!-- For build compatibility with Java 11 -->
+            Import-Package: \
+              javax.annotation;version="[0.0,2)",\
+              *
+          </bnd>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-baseline-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <distributionManagement>
+    <site>
+      <id>${site.deploy.id}</id>
+      <url>${site.deploy.url}${site.url.module.prefix}</url>
+    </site>
+  </distributionManagement>
+
+</project>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -192,14 +192,6 @@
           </archive>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>9</source>
-          <target>9</target>
-        </configuration>
-      </plugin>
 
     </plugins>
   </build>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -99,6 +99,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-matchers</artifactId>
+      <version>2.8.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
       <version>4.0.0</version>

--- a/utils/src/main/java/io/wcm/wcm/utils/PageLanguageHandler.java
+++ b/utils/src/main/java/io/wcm/wcm/utils/PageLanguageHandler.java
@@ -1,0 +1,64 @@
+package io.wcm.wcm.utils;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import io.wcm.handler.url.UrlHandler;
+import io.wcm.handler.url.ui.SiteRoot;
+import io.wcm.sling.models.annotations.AemObject;
+import io.wcm.wcm.commons.contenttype.FileExtension;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Model that allows access to alternative languages of a page
+ */
+@Model(adaptables = { SlingHttpServletRequest.class, Resource.class })
+public class PageLanguageHandler {
+
+  @AemObject
+  private PageManager pageManager;
+
+  /**
+   * @return map of all alternative language versions of the page
+   */
+  public Map<Locale, String> getAlternativeLanguageUrls(Page page) {
+    Map<Locale, String> ret = new HashMap<>();
+    SiteRoot siteRoot = page.adaptTo(SiteRoot.class);
+    if (siteRoot == null)
+      return ret;
+
+    Page siteRootPage = siteRoot.getRootPage();
+
+    String relativePath = StringUtils.substringAfter(page.getPath(), siteRootPage.getPath());
+
+    // /content/XYZ
+    Page countryRoot = siteRootPage.getParent(2);
+
+    for (Iterator<Page> countryRootPages = countryRoot.listChildren(); countryRootPages.hasNext(); ) {
+      Page countryRootPage = countryRootPages.next();
+      for (Iterator<Page> languageRootPages = countryRootPage.listChildren(); languageRootPages.hasNext(); ) {
+        Page languageRoot = languageRootPages.next();
+
+        Page alternativeVersion = pageManager.getPage(languageRoot.getPath() + relativePath);
+        if (alternativeVersion != null) {
+          UrlHandler urlHandler = alternativeVersion.adaptTo(UrlHandler.class);
+          if (urlHandler != null) {
+            String pageUrl = urlHandler.get(alternativeVersion).extension(FileExtension.HTML).buildExternalLinkUrl();
+            if (StringUtils.isNotBlank(pageUrl))
+              ret.put(alternativeVersion.getLanguage(), pageUrl);
+          }
+        }
+      }
+    }
+    return ret;
+  }
+
+
+}

--- a/utils/src/main/java/io/wcm/wcm/utils/PageLanguageHandler.java
+++ b/utils/src/main/java/io/wcm/wcm/utils/PageLanguageHandler.java
@@ -43,6 +43,9 @@ public class PageLanguageHandler {
     // assuming ../country/language structure
     Page countryRoot = siteRootPage.getParent(2);
 
+    if(countryRoot == null)
+      return ret;
+
     for (Iterator<Page> countryRootPages = countryRoot.listChildren(); countryRootPages.hasNext(); ) {
       Page countryRootPage = countryRootPages.next();
       for (Iterator<Page> languageRootPages = countryRootPage.listChildren(); languageRootPages.hasNext(); ) {

--- a/utils/src/main/java/io/wcm/wcm/utils/PageLanguageHandler.java
+++ b/utils/src/main/java/io/wcm/wcm/utils/PageLanguageHandler.java
@@ -2,10 +2,12 @@ package io.wcm.wcm.utils;
 
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
+
 import io.wcm.handler.url.UrlHandler;
 import io.wcm.handler.url.ui.SiteRoot;
 import io.wcm.sling.models.annotations.AemObject;
 import io.wcm.wcm.commons.contenttype.FileExtension;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -26,7 +28,7 @@ public class PageLanguageHandler {
   private PageManager pageManager;
 
   /**
-   * @return map of all alternative language versions of the page
+   * @return map of all alternative language versions of the page (including itself)
    */
   public Map<Locale, String> getAlternativeLanguageUrls(Page page) {
     Map<Locale, String> ret = new HashMap<>();
@@ -38,7 +40,7 @@ public class PageLanguageHandler {
 
     String relativePath = StringUtils.substringAfter(page.getPath(), siteRootPage.getPath());
 
-    // /content/XYZ
+    // assuming ../country/language structure
     Page countryRoot = siteRootPage.getParent(2);
 
     for (Iterator<Page> countryRootPages = countryRoot.listChildren(); countryRootPages.hasNext(); ) {
@@ -59,6 +61,4 @@ public class PageLanguageHandler {
     }
     return ret;
   }
-
-
 }

--- a/utils/src/main/java/io/wcm/wcm/utils/sitemap/SiteMapServlet.java
+++ b/utils/src/main/java/io/wcm/wcm/utils/sitemap/SiteMapServlet.java
@@ -1,0 +1,169 @@
+package io.wcm.wcm.utils.sitemap;
+
+import com.day.cq.commons.date.DateUtil;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageFilter;
+import com.day.cq.wcm.api.PageManager;
+import io.wcm.handler.url.UrlHandler;
+import io.wcm.handler.url.ui.SiteRoot;
+import io.wcm.wcm.commons.contenttype.FileExtension;
+import io.wcm.wcm.commons.util.Template;
+import io.wcm.wcm.utils.PageLanguageHandler;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.vault.util.PathUtil;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configurable Servlet that provides a Sitemap XML at _jcr_content.sitemap.xml
+ */
+@Component(service = Servlet.class, property = {
+        "sling.servlet.selectors=sitemap",
+        "sling.servlet.extensions=xml",
+        "sling.servlet.methods=GET"
+}, configurationPolicy = ConfigurationPolicy.REQUIRE)
+@Designate(ocd = SiteMapServlet.Config.class, factory = true)
+public class SiteMapServlet extends SlingSafeMethodsServlet {
+
+    private static final Namespace NAMESPACE = Namespace.getNamespace("http://www.sitemaps.org/schemas/sitemap/0.9");
+    private static final Namespace NAMESPACE_XHTML = Namespace.getNamespace("http://www.w3.org/1999/xhtml");
+
+    private SiteMapServlet.Config config;
+
+    private List<Pattern> excludedPath;
+
+    @Activate
+    void activate(SiteMapServlet.Config config) {
+        this.config = config;
+
+        this.excludedPath = Arrays.stream(config.excludedPaths()).map(Pattern::compile).collect(Collectors.toList());
+    }
+
+    @Override
+    protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("application/xml");
+        response.setCharacterEncoding("utf-8");
+
+        Document xmlDocument = new Document();
+        Element rootElement = new Element("urlset", NAMESPACE);
+        xmlDocument.setRootElement(rootElement);
+
+        writeSiteMap(request, rootElement);
+
+        XMLOutputter outputter = new XMLOutputter(Format.getPrettyFormat());
+        OutputStream out = response.getOutputStream();
+        outputter.output(xmlDocument, out);
+    }
+
+    private void writeSiteMap(SlingHttpServletRequest request, Element rootElement) {
+        ResourceResolver resourceResolver = request.getResourceResolver();
+        PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
+        Page page = pageManager.getContainingPage(request.getResource());
+        PageLanguageHandler pageLanguageHandler = request.adaptTo(PageLanguageHandler.class);
+        UrlHandler urlHandler = request.adaptTo(UrlHandler.class);
+
+        writePageEntry(urlHandler, rootElement, pageLanguageHandler, page);
+    }
+
+    private void writePageEntry(UrlHandler urlHandler, Element rootElement, PageLanguageHandler pageLanguageHandler, Page page) {
+        if (included(page)) {
+            Element urlElement = createUrlElement(urlHandler, page);
+            rootElement.addContent(urlElement);
+
+            pageLanguageHandler.getAlternativeLanguageUrls(page).forEach((key, value) -> urlElement.addContent(createLinkEntry(value, key)));
+
+        }
+        Iterator<Page> pageIterator = page.listChildren(new PageFilter(false, true));
+        while (pageIterator.hasNext()) {
+            Page child = pageIterator.next();
+            writePageEntry(urlHandler, rootElement, pageLanguageHandler, child);
+        }
+    }
+
+    private Element createUrlElement(UrlHandler urlHandler, Page page) {
+        String url = urlHandler.get(page).extension(FileExtension.HTML).buildExternalLinkUrl();
+
+        Element urlElement = new Element("url", NAMESPACE);
+        Element locElement = new Element("loc", NAMESPACE).setText(url);
+        urlElement.addContent(locElement);
+
+        Float priority = page.getProperties().get(config.propertyPriority(), Float.class);
+        if (priority != null) {
+            Element priorityElement = new Element("priority", NAMESPACE).setText(priority.toString());
+            urlElement.addContent(priorityElement);
+        }
+        if (page.getLastModified() != null) {
+            Element lastModElement = new Element("lastMode", NAMESPACE).setText(DateUtil.getISO8601Date(page.getLastModified()));
+            urlElement.addContent(lastModElement);
+        }
+        return urlElement;
+    }
+
+    private Element createLinkEntry(String link, Locale locale) {
+        Element linkElement = new Element("link", NAMESPACE_XHTML);
+        linkElement.setAttribute("rel", "alternate");
+        linkElement.setAttribute("hreflang", locale.toLanguageTag());
+        linkElement.setAttribute("href", link);
+        return linkElement;
+    }
+
+    private boolean included(Page page) {
+        return (!page.getProperties().get(config.propertyExclude(), false)
+                && Arrays.stream(config.excludedTemplates()).noneMatch(it -> Template.is(page, it))
+                && excludedPath.stream().noneMatch(it -> it.matcher(page.getPath()).matches()));
+    }
+
+    /**
+     * Configuration definition
+     */
+    @ObjectClassDefinition(name = "wcm.io - Sitemap",
+            description = "Servlet for Sitemap generation")
+    public @interface Config {
+
+        @AttributeDefinition(name = "Sling Resource Type", description = "Sling Resource Type for the Home Page.")
+        String[] sling_servlet_resourceTypes() default {};
+
+        @AttributeDefinition(name = "Excluded paths", description = "Excluded Path Regex")
+        String[] excludedPaths() default {};
+
+        @AttributeDefinition(name = "Excluded templates", description = "Excluded templates")
+        String[] excludedTemplates() default {};
+
+        @AttributeDefinition(name = "Priority property", description = "Property")
+        String propertyPriority() default "siteMapPriority";
+
+        @AttributeDefinition(name = "Exclude property", description = "Page Property indicating that the page should be excluded from sitemap")
+        String propertyExclude() default "siteMapExcluded";
+
+    }
+}

--- a/utils/src/main/java/io/wcm/wcm/utils/sitemap/SiteMapServlet.java
+++ b/utils/src/main/java/io/wcm/wcm/utils/sitemap/SiteMapServlet.java
@@ -1,21 +1,18 @@
 package io.wcm.wcm.utils.sitemap;
 
-import com.day.cq.commons.date.DateUtil;
-import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageFilter;
-import com.day.cq.wcm.api.PageManager;
-import io.wcm.handler.url.UrlHandler;
-import io.wcm.handler.url.ui.SiteRoot;
-import io.wcm.wcm.commons.contenttype.FileExtension;
-import io.wcm.wcm.commons.util.Template;
-import io.wcm.wcm.utils.PageLanguageHandler;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jackrabbit.vault.util.PathUtil;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -29,141 +26,136 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import com.day.cq.commons.date.DateUtil;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageFilter;
+import com.day.cq.wcm.api.PageManager;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.*;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.wcm.handler.url.UrlHandler;
+import io.wcm.wcm.commons.contenttype.FileExtension;
+import io.wcm.wcm.commons.util.Template;
+import io.wcm.wcm.utils.PageLanguageHandler;
 
 /**
  * Configurable Servlet that provides a Sitemap XML at _jcr_content.sitemap.xml
  */
 @Component(service = Servlet.class, property = {
-        "sling.servlet.selectors=sitemap",
-        "sling.servlet.extensions=xml",
-        "sling.servlet.methods=GET"
+    "sling.servlet.selectors=sitemap",
+    "sling.servlet.extensions=xml",
+    "sling.servlet.methods=GET"
 }, configurationPolicy = ConfigurationPolicy.REQUIRE)
 @Designate(ocd = SiteMapServlet.Config.class, factory = true)
 public class SiteMapServlet extends SlingSafeMethodsServlet {
 
-    private static final Namespace NAMESPACE = Namespace.getNamespace("http://www.sitemaps.org/schemas/sitemap/0.9");
-    private static final Namespace NAMESPACE_XHTML = Namespace.getNamespace("http://www.w3.org/1999/xhtml");
+  private static final Namespace NAMESPACE = Namespace.getNamespace("http://www.sitemaps.org/schemas/sitemap/0.9");
+  private static final Namespace NAMESPACE_XHTML = Namespace.getNamespace("http://www.w3.org/1999/xhtml");
 
-    private SiteMapServlet.Config config;
+  private SiteMapServlet.Config config;
 
-    private List<Pattern> excludedPath;
+  private List<Pattern> excludedPath;
 
-    @Activate
-    void activate(SiteMapServlet.Config config) {
-        this.config = config;
+  @Activate
+  void activate(SiteMapServlet.Config config) {
+    this.config = config;
 
-        this.excludedPath = Arrays.stream(config.excludedPaths()).map(Pattern::compile).collect(Collectors.toList());
-    }
+    this.excludedPath = Arrays.stream(config.excludedPaths()).map(Pattern::compile).collect(Collectors.toList());
+  }
 
-    @Override
-    protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
-        response.setContentType("application/xml");
-        response.setCharacterEncoding("utf-8");
+  @Override
+  protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws ServletException, IOException {
+    response.setContentType("application/xml");
+    response.setCharacterEncoding("utf-8");
 
-        Document xmlDocument = new Document();
-        Element rootElement = new Element("urlset", NAMESPACE);
-        xmlDocument.setRootElement(rootElement);
+    Document xmlDocument = new Document();
+    Element rootElement = new Element("urlset", NAMESPACE);
+    xmlDocument.setRootElement(rootElement);
 
-        writeSiteMap(request, rootElement);
+    writeSiteMap(request, rootElement);
 
-        XMLOutputter outputter = new XMLOutputter(Format.getPrettyFormat());
-        OutputStream out = response.getOutputStream();
-        outputter.output(xmlDocument, out);
-    }
+    XMLOutputter outputter = new XMLOutputter(Format.getPrettyFormat());
+    OutputStream out = response.getOutputStream();
+    outputter.output(xmlDocument, out);
+  }
 
-    private void writeSiteMap(SlingHttpServletRequest request, Element rootElement) {
-        ResourceResolver resourceResolver = request.getResourceResolver();
-        PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
-        Page page = pageManager.getContainingPage(request.getResource());
-        PageLanguageHandler pageLanguageHandler = request.adaptTo(PageLanguageHandler.class);
-        UrlHandler urlHandler = request.adaptTo(UrlHandler.class);
+  private void writeSiteMap(SlingHttpServletRequest request, Element rootElement) {
+    ResourceResolver resourceResolver = request.getResourceResolver();
+    PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
+    Page page = pageManager.getContainingPage(request.getResource());
+    PageLanguageHandler pageLanguageHandler = request.adaptTo(PageLanguageHandler.class);
+    UrlHandler urlHandler = request.adaptTo(UrlHandler.class);
 
-        writePageEntry(urlHandler, rootElement, pageLanguageHandler, page);
-    }
+    writePageEntry(urlHandler, rootElement, pageLanguageHandler, page);
+  }
 
-    private void writePageEntry(UrlHandler urlHandler, Element rootElement, PageLanguageHandler pageLanguageHandler, Page page) {
-        if (included(page)) {
-            Element urlElement = createUrlElement(urlHandler, page);
-            rootElement.addContent(urlElement);
+  private void writePageEntry(UrlHandler urlHandler, Element rootElement, PageLanguageHandler pageLanguageHandler, Page page) {
+    if (included(page)) {
+      Element urlElement = createUrlElement(urlHandler, page);
+      rootElement.addContent(urlElement);
 
-            pageLanguageHandler.getAlternativeLanguageUrls(page).forEach((key, value) -> urlElement.addContent(createLinkEntry(value, key)));
-
-        }
-        Iterator<Page> pageIterator = page.listChildren(new PageFilter(false, true));
-        while (pageIterator.hasNext()) {
-            Page child = pageIterator.next();
-            writePageEntry(urlHandler, rootElement, pageLanguageHandler, child);
-        }
-    }
-
-    private Element createUrlElement(UrlHandler urlHandler, Page page) {
-        String url = urlHandler.get(page).extension(FileExtension.HTML).buildExternalLinkUrl();
-
-        Element urlElement = new Element("url", NAMESPACE);
-        Element locElement = new Element("loc", NAMESPACE).setText(url);
-        urlElement.addContent(locElement);
-
-        Float priority = page.getProperties().get(config.propertyPriority(), Float.class);
-        if (priority != null) {
-            Element priorityElement = new Element("priority", NAMESPACE).setText(priority.toString());
-            urlElement.addContent(priorityElement);
-        }
-        if (page.getLastModified() != null) {
-            Element lastModElement = new Element("lastMode", NAMESPACE).setText(DateUtil.getISO8601Date(page.getLastModified()));
-            urlElement.addContent(lastModElement);
-        }
-        return urlElement;
-    }
-
-    private Element createLinkEntry(String link, Locale locale) {
-        Element linkElement = new Element("link", NAMESPACE_XHTML);
-        linkElement.setAttribute("rel", "alternate");
-        linkElement.setAttribute("hreflang", locale.toLanguageTag());
-        linkElement.setAttribute("href", link);
-        return linkElement;
-    }
-
-    private boolean included(Page page) {
-        return (!page.getProperties().get(config.propertyExclude(), false)
-                && Arrays.stream(config.excludedTemplates()).noneMatch(it -> Template.is(page, it))
-                && excludedPath.stream().noneMatch(it -> it.matcher(page.getPath()).matches()));
-    }
-
-    /**
-     * Configuration definition
-     */
-    @ObjectClassDefinition(name = "wcm.io - Sitemap",
-            description = "Servlet for Sitemap generation")
-    public @interface Config {
-
-        @AttributeDefinition(name = "Sling Resource Type", description = "Sling Resource Type for the Home Page.")
-        String[] sling_servlet_resourceTypes() default {};
-
-        @AttributeDefinition(name = "Excluded paths", description = "Excluded Path Regex")
-        String[] excludedPaths() default {};
-
-        @AttributeDefinition(name = "Excluded templates", description = "Excluded templates")
-        String[] excludedTemplates() default {};
-
-        @AttributeDefinition(name = "Priority property", description = "Property")
-        String propertyPriority() default "siteMapPriority";
-
-        @AttributeDefinition(name = "Exclude property", description = "Page Property indicating that the page should be excluded from sitemap")
-        String propertyExclude() default "siteMapExcluded";
+      pageLanguageHandler.getAlternativeLanguageUrls(page).forEach((key, value) -> urlElement.addContent(createLinkEntry(value, key)));
 
     }
+    Iterator<Page> pageIterator = page.listChildren(new PageFilter(false, true));
+    while (pageIterator.hasNext()) {
+      Page child = pageIterator.next();
+      writePageEntry(urlHandler, rootElement, pageLanguageHandler, child);
+    }
+  }
+
+  private Element createUrlElement(UrlHandler urlHandler, Page page) {
+    String url = urlHandler.get(page).extension(FileExtension.HTML).buildExternalLinkUrl();
+
+    Element urlElement = new Element("url", NAMESPACE);
+    Element locElement = new Element("loc", NAMESPACE).setText(url);
+    urlElement.addContent(locElement);
+
+    Float priority = page.getProperties().get(config.propertyPriority(), Float.class);
+    if (priority != null) {
+      Element priorityElement = new Element("priority", NAMESPACE).setText(priority.toString());
+      urlElement.addContent(priorityElement);
+    }
+    if (page.getLastModified() != null) {
+      Element lastModElement = new Element("lastMode", NAMESPACE).setText(DateUtil.getISO8601Date(page.getLastModified()));
+      urlElement.addContent(lastModElement);
+    }
+    return urlElement;
+  }
+
+  private Element createLinkEntry(String link, Locale locale) {
+    Element linkElement = new Element("link", NAMESPACE_XHTML);
+    linkElement.setAttribute("rel", "alternate");
+    linkElement.setAttribute("hreflang", locale.toLanguageTag());
+    linkElement.setAttribute("href", link);
+    return linkElement;
+  }
+
+  private boolean included(Page page) {
+    return (!page.getProperties().get(config.propertyExclude(), false)
+        && Arrays.stream(config.excludedTemplates()).noneMatch(it -> Template.is(page, it))
+        && excludedPath.stream().noneMatch(it -> it.matcher(page.getPath()).matches()));
+  }
+
+  /**
+   * Configuration definition
+   */
+  @ObjectClassDefinition(name = "wcm.io - Sitemap",
+      description = "Servlet for Sitemap generation")
+  public @interface Config {
+
+    @AttributeDefinition(name = "Sling Resource Type", description = "Sling Resource Type for the Home Page.")
+    String[] sling_servlet_resourceTypes() default {};
+
+    @AttributeDefinition(name = "Excluded paths", description = "Excluded Path Regex")
+    String[] excludedPaths() default {};
+
+    @AttributeDefinition(name = "Excluded templates", description = "Excluded templates")
+    String[] excludedTemplates() default {};
+
+    @AttributeDefinition(name = "Priority property", description = "Property")
+    String propertyPriority() default "siteMapPriority";
+
+    @AttributeDefinition(name = "Exclude property", description = "Page Property indicating that the page should be excluded from sitemap")
+    String propertyExclude() default "siteMapExcluded";
+
+  }
 }

--- a/utils/src/main/java/io/wcm/wcm/utils/sitemap/SiteMapServlet.java
+++ b/utils/src/main/java/io/wcm/wcm/utils/sitemap/SiteMapServlet.java
@@ -48,7 +48,7 @@ import io.wcm.wcm.utils.PageLanguageHandler;
 public class SiteMapServlet extends SlingSafeMethodsServlet {
 
   private static final Namespace NAMESPACE = Namespace.getNamespace("http://www.sitemaps.org/schemas/sitemap/0.9");
-  private static final Namespace NAMESPACE_XHTML = Namespace.getNamespace("http://www.w3.org/1999/xhtml");
+  private static final Namespace NAMESPACE_XHTML = Namespace.getNamespace("xhtml", "http://www.w3.org/1999/xhtml");
 
   private SiteMapServlet.Config config;
 
@@ -68,6 +68,7 @@ public class SiteMapServlet extends SlingSafeMethodsServlet {
 
     Document xmlDocument = new Document();
     Element rootElement = new Element("urlset", NAMESPACE);
+    rootElement.addNamespaceDeclaration(NAMESPACE_XHTML);
     xmlDocument.setRootElement(rootElement);
 
     writeSiteMap(request, rootElement);
@@ -115,7 +116,7 @@ public class SiteMapServlet extends SlingSafeMethodsServlet {
       urlElement.addContent(priorityElement);
     }
     if (page.getLastModified() != null) {
-      Element lastModElement = new Element("lastMode", NAMESPACE).setText(DateUtil.getISO8601Date(page.getLastModified()));
+      Element lastModElement = new Element("lastmod", NAMESPACE).setText(DateUtil.getISO8601DateNoTime(page.getLastModified()));
       urlElement.addContent(lastModElement);
     }
     return urlElement;

--- a/utils/src/test/java/io/wcm/wcm/utils/PageLanguageHandlerTest.java
+++ b/utils/src/test/java/io/wcm/wcm/utils/PageLanguageHandlerTest.java
@@ -32,10 +32,11 @@ class PageLanguageHandlerTest {
   void getAlternativeLanguages_rootPage() {
     Map<Locale, String> alternativeLanguageUrls = underTest.getAlternativeLanguageUrls(context.pageManager().getPage("/content/foo/en/en"));
 
-    assertEquals(2, alternativeLanguageUrls.size());
+    assertEquals(3, alternativeLanguageUrls.size());
 
     assertEquals("/content/foo/en/en.html", alternativeLanguageUrls.get(Locale.ENGLISH));
     assertEquals("/content/foo/en/de.html", alternativeLanguageUrls.get(Locale.GERMAN));
+    assertEquals("/content/foo/en/fr.html", alternativeLanguageUrls.get(Locale.FRANCE));
   }
 
 

--- a/utils/src/test/java/io/wcm/wcm/utils/PageLanguageHandlerTest.java
+++ b/utils/src/test/java/io/wcm/wcm/utils/PageLanguageHandlerTest.java
@@ -1,0 +1,76 @@
+package io.wcm.wcm.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.wcm.utils.testcontext.AppAemContext;
+
+
+@ExtendWith(AemContextExtension.class)
+class PageLanguageHandlerTest {
+
+  private final AemContext context = AppAemContext.newAemContext();
+
+
+  @Test
+  void getAlternativeLanguages_rootPage() {
+    context.create().page("/content");
+    context.create().page("/content/en");
+    context.create().page("/content/en/fr");
+    context.currentPage(context.create().page("/content/en/de"));
+
+    PageLanguageHandler underTest = context.request().adaptTo(PageLanguageHandler.class);
+    Map<Locale, String> alternativeLanguageUrls = underTest.getAlternativeLanguageUrls(context.currentPage());
+
+    assertEquals(2, alternativeLanguageUrls.size());
+
+    assertEquals("/content/en/fr.html", alternativeLanguageUrls.get(Locale.FRENCH));
+    assertEquals("/content/en/de.html", alternativeLanguageUrls.get(Locale.GERMAN));
+  }
+
+
+  @Test
+  void getAlternativeLanguages_nestedPage() {
+    context.create().page("/content");
+    context.create().page("/content/en");
+    context.create().page("/content/en/fr");
+    context.create().page("/content/en/fr/foo");
+    context.create().page("/content/en/fr/foo/bar");
+
+    context.create().page("/content/en/es");
+    context.create().page("/content/en/es/foo");
+
+    context.create().page("/content/en/de");
+    context.create().page("/content/en/de/foo");
+    context.currentPage(context.create().page("/content/en/de/foo/bar"));
+
+    PageLanguageHandler underTest = context.request().adaptTo(PageLanguageHandler.class);
+    Map<Locale, String> alternativeLanguageUrls = underTest.getAlternativeLanguageUrls(context.currentPage());
+
+    assertEquals(2, alternativeLanguageUrls.size());
+
+    assertEquals("/content/en/fr/foo/bar.html", alternativeLanguageUrls.get(Locale.FRENCH));
+    assertEquals("/content/en/de/foo/bar.html", alternativeLanguageUrls.get(Locale.GERMAN));
+  }
+
+  @Test
+  void getAlternativeLanguages_noOtherPages() {
+    context.create().page("/content");
+    context.create().page("/content/en");
+    context.currentPage(context.create().page("/content/en/de"));
+
+    PageLanguageHandler underTest = context.request().adaptTo(PageLanguageHandler.class);
+    Map<Locale, String> alternativeLanguageUrls = underTest.getAlternativeLanguageUrls(context.currentPage());
+
+    assertEquals(1, alternativeLanguageUrls.size());
+
+    assertEquals("/content/en/de.html", alternativeLanguageUrls.get(Locale.GERMAN));
+  }
+
+}

--- a/utils/src/test/java/io/wcm/wcm/utils/sitemap/SiteMapServletTest.java
+++ b/utils/src/test/java/io/wcm/wcm/utils/sitemap/SiteMapServletTest.java
@@ -1,0 +1,166 @@
+package io.wcm.wcm.utils.sitemap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.wcm.utils.testcontext.AppAemContext;
+
+@ExtendWith(AemContextExtension.class)
+class SiteMapServletTest {
+
+  private static final Map<String, String> NAMESPACE = new HashMap<>();
+
+  static {
+    NAMESPACE.put("ns", "http://www.sitemaps.org/schemas/sitemap/0.9");
+    NAMESPACE.put("xhtml", "http://www.w3.org/1999/xhtml");
+  }
+
+  private final AemContext context = AppAemContext.newAemContext();
+
+  private MockSlingHttpServletRequest request;
+
+  private SiteMapServlet underTest = new SiteMapServlet();
+
+  @BeforeEach
+  public void setup() {
+    context.load().json("/sitemap/sitemapservlet-sample.json", "/content");
+
+    request = new MockSlingHttpServletRequest(context.resourceResolver(), context.bundleContext()) {
+
+      @Override
+      public String getResponseContentType() {
+        return "text/xml";
+      }
+    };
+
+  }
+
+  @Test
+  public void defaultSetup() throws Exception {
+    Map<String, Object> parameters = new HashMap<>();
+
+    context.registerInjectActivateService(underTest, parameters);
+
+    request.setResource(context.resourceResolver().getResource("/content/foo/en/en"));
+    underTest.doGet(request, context.response());
+    String output = context.response().getOutputAsString();
+
+    assertThat(output, hasXPath("count(//ns:loc)", equalTo("3")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[1]/text()", equalTo("/content/foo/en/en.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:lastmod)[1]/text()", equalTo("2021-01-01")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[2]/text()", equalTo("/content/foo/en/en/events.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[3]/text()", equalTo("/content/foo/en/en/about.html")).withNamespaceContext(NAMESPACE));
+  }
+
+
+  @Test
+  public void exclude_property() throws Exception {
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("propertyExclude", "customExcludeProperty");
+    context.registerInjectActivateService(underTest, parameters);
+
+    request.setResource(context.resourceResolver().getResource("/content/foo/en/en"));
+    underTest.doGet(request, context.response());
+
+    String output = context.response().getOutputAsString();
+
+    assertThat(output, hasXPath("count(//ns:loc)", equalTo("2")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[1]/text()", equalTo("/content/foo/en/en.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[2]/text()", equalTo("/content/foo/en/en/about.html")).withNamespaceContext(NAMESPACE));
+  }
+
+  @Test
+  public void priority_property() throws Exception {
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("propertyPriority", "customPriorityProperty");
+    context.registerInjectActivateService(underTest, parameters);
+
+    request.setResource(context.resourceResolver().getResource("/content/foo/en/en"));
+    underTest.doGet(request, context.response());
+
+    String output = context.response().getOutputAsString();
+
+
+    assertThat(output, hasXPath("count(//ns:loc)", equalTo("3")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[1]/text()", equalTo("/content/foo/en/en.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:priority)[1]/text()", equalTo("0.75")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[2]/text()", equalTo("/content/foo/en/en/events.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:priority)[2]/text()", equalTo("1.0")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[3]/text()", equalTo("/content/foo/en/en/about.html")).withNamespaceContext(NAMESPACE));
+  }
+
+  @Test
+  public void exclude_path() throws Exception {
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("excludedPaths", "/content/foo/en/en/.*");
+    context.registerInjectActivateService(underTest, parameters);
+
+    request.setResource(context.resourceResolver().getResource("/content/foo/en/en"));
+    underTest.doGet(request, context.response());
+
+    String output = context.response().getOutputAsString();
+
+    assertThat(output, hasXPath("count(//ns:loc)", equalTo("1")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[1]/text()", equalTo("/content/foo/en/en.html")).withNamespaceContext(NAMESPACE));
+  }
+
+  @Test
+  public void exclude_template() throws Exception {
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("excludedTemplates", "/foo/template2");
+    context.registerInjectActivateService(underTest, parameters);
+
+    request.setResource(context.resourceResolver().getResource("/content/foo/en/en"));
+    underTest.doGet(request, context.response());
+
+    String output = context.response().getOutputAsString();
+
+    assertThat(output, hasXPath("count(//ns:loc)", equalTo("2")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[1]/text()", equalTo("/content/foo/en/en.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[2]/text()", equalTo("/content/foo/en/en/about.html")).withNamespaceContext(NAMESPACE));
+  }
+
+
+  @Test
+  public void alternativeLanguages() throws Exception {
+
+    Map<String, Object> parameters = new HashMap<>();
+    context.registerInjectActivateService(underTest, parameters);
+
+    request.setResource(context.resourceResolver().getResource("/content/foo/en/en"));
+    underTest.doGet(request, context.response());
+
+    String output = context.response().getOutputAsString();
+
+    assertThat(output, hasXPath("count(//ns:loc)", equalTo("3")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//ns:loc)[1]/text()", equalTo("/content/foo/en/en.html")).withNamespaceContext(NAMESPACE));
+
+    assertThat(output, hasXPath("(//xhtml:link)[1]/@href", equalTo("/content/foo/en/de.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[1]/@hreflang", equalTo("de")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[2]/@href", equalTo("/content/foo/en/en.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[2]/@hreflang", equalTo("en")).withNamespaceContext(NAMESPACE));
+
+    assertThat(output, hasXPath("(//ns:loc)[2]/text()", equalTo("/content/foo/en/en/events.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[3]/@href", equalTo("/content/foo/en/de/events.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[3]/@hreflang", equalTo("de")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[4]/@href", equalTo("/content/foo/en/en/events.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[4]/@hreflang", equalTo("en")).withNamespaceContext(NAMESPACE));
+
+    assertThat(output, hasXPath("(//ns:loc)[3]/text()", equalTo("/content/foo/en/en/about.html")).withNamespaceContext(NAMESPACE));
+  }
+}

--- a/utils/src/test/java/io/wcm/wcm/utils/sitemap/SiteMapServletTest.java
+++ b/utils/src/test/java/io/wcm/wcm/utils/sitemap/SiteMapServletTest.java
@@ -135,7 +135,6 @@ class SiteMapServletTest {
     assertThat(output, hasXPath("(//ns:loc)[2]/text()", equalTo("/content/foo/en/en/about.html")).withNamespaceContext(NAMESPACE));
   }
 
-
   @Test
   public void alternativeLanguages() throws Exception {
 
@@ -154,12 +153,14 @@ class SiteMapServletTest {
     assertThat(output, hasXPath("(//xhtml:link)[1]/@hreflang", equalTo("de")).withNamespaceContext(NAMESPACE));
     assertThat(output, hasXPath("(//xhtml:link)[2]/@href", equalTo("/content/foo/en/en.html")).withNamespaceContext(NAMESPACE));
     assertThat(output, hasXPath("(//xhtml:link)[2]/@hreflang", equalTo("en")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[3]/@href", equalTo("/content/foo/en/fr.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[3]/@hreflang", equalTo("fr-FR")).withNamespaceContext(NAMESPACE));
 
     assertThat(output, hasXPath("(//ns:loc)[2]/text()", equalTo("/content/foo/en/en/events.html")).withNamespaceContext(NAMESPACE));
-    assertThat(output, hasXPath("(//xhtml:link)[3]/@href", equalTo("/content/foo/en/de/events.html")).withNamespaceContext(NAMESPACE));
-    assertThat(output, hasXPath("(//xhtml:link)[3]/@hreflang", equalTo("de")).withNamespaceContext(NAMESPACE));
-    assertThat(output, hasXPath("(//xhtml:link)[4]/@href", equalTo("/content/foo/en/en/events.html")).withNamespaceContext(NAMESPACE));
-    assertThat(output, hasXPath("(//xhtml:link)[4]/@hreflang", equalTo("en")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[4]/@href", equalTo("/content/foo/en/de/events.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[4]/@hreflang", equalTo("de")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[5]/@href", equalTo("/content/foo/en/en/events.html")).withNamespaceContext(NAMESPACE));
+    assertThat(output, hasXPath("(//xhtml:link)[5]/@hreflang", equalTo("en")).withNamespaceContext(NAMESPACE));
 
     assertThat(output, hasXPath("(//ns:loc)[3]/text()", equalTo("/content/foo/en/en/about.html")).withNamespaceContext(NAMESPACE));
   }

--- a/utils/src/test/java/io/wcm/wcm/utils/testcontext/AppAemContext.java
+++ b/utils/src/test/java/io/wcm/wcm/utils/testcontext/AppAemContext.java
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2014 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.wcm.utils.testcontext;
+
+import static io.wcm.testing.mock.wcmio.caconfig.ContextPlugins.WCMIO_CACONFIG;
+import static io.wcm.testing.mock.wcmio.sling.ContextPlugins.WCMIO_SLING;
+import static io.wcm.testing.mock.wcmio.wcm.ContextPlugins.WCMIO_WCM;
+import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
+
+import org.apache.sling.testing.mock.caconfig.MockContextAwareConfig;
+
+import io.wcm.handler.url.SiteConfig;
+import io.wcm.handler.url.impl.DefaultUrlHandlerConfig;
+import io.wcm.handler.url.impl.SiteRootDetectorImpl;
+import io.wcm.handler.url.impl.UrlHandlerAdapterFactory;
+import io.wcm.handler.url.impl.clientlib.ClientlibProxyRewriterImpl;
+import io.wcm.handler.url.spi.UrlHandlerConfig;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextCallback;
+import io.wcm.testing.mock.wcmio.caconfig.MockCAConfig;
+
+/**
+ * Sets up {@link AemContext} for unit tests in this application.
+ */
+public final class AppAemContext {
+
+  private AppAemContext() {
+    // static methods only
+  }
+
+  public static AemContext newAemContext() {
+    return new AemContextBuilder()
+        .plugin(CACONFIG)
+        .plugin(WCMIO_SLING, WCMIO_WCM, WCMIO_CACONFIG)
+        .afterSetUp(SETUP_CALLBACK)
+        .build();
+  }
+
+  /**
+   * Custom set up rules required in all unit tests.
+   */
+  private static final AemContextCallback SETUP_CALLBACK = context -> {
+    // register sling models
+    context.addModelsForPackage("io.wcm.wcm.utils");
+
+    // handler SPI
+    context.registerInjectActivateService(new SiteRootDetectorImpl());
+    context.registerInjectActivateService(new UrlHandlerAdapterFactory());
+    context.registerInjectActivateService(new ClientlibProxyRewriterImpl());
+    context.registerInjectActivateService(new DefaultUrlHandlerConfig());
+    context.registerService(UrlHandlerConfig.class, new DummyUrlHandlerConfig());
+
+    // register configuration classes
+    MockContextAwareConfig.registerAnnotationClasses(context, SiteConfig.class);
+
+    // context path strategy
+    MockCAConfig.contextPathStrategyAbsoluteParent(context, DummyUrlHandlerConfig.SITE_ROOT_LEVEL);
+  };
+
+}

--- a/utils/src/test/java/io/wcm/wcm/utils/testcontext/DummyUrlHandlerConfig.java
+++ b/utils/src/test/java/io/wcm/wcm/utils/testcontext/DummyUrlHandlerConfig.java
@@ -14,7 +14,7 @@ import io.wcm.handler.url.spi.UrlHandlerConfig;
 @SuppressWarnings("null")
 public class DummyUrlHandlerConfig extends UrlHandlerConfig {
 
-  public static final int SITE_ROOT_LEVEL = 2;
+  public static final int SITE_ROOT_LEVEL = 3;
 
   @Override
   public List<IntegratorMode> getIntegratorModes() {

--- a/utils/src/test/java/io/wcm/wcm/utils/testcontext/DummyUrlHandlerConfig.java
+++ b/utils/src/test/java/io/wcm/wcm/utils/testcontext/DummyUrlHandlerConfig.java
@@ -1,0 +1,39 @@
+package io.wcm.wcm.utils.testcontext;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sling.api.resource.Resource;
+import com.day.cq.wcm.api.Page;
+
+import io.wcm.handler.url.integrator.IntegratorMode;
+import io.wcm.handler.url.spi.UrlHandlerConfig;
+
+/**
+ * Dummy link configuration
+ */
+@SuppressWarnings("null")
+public class DummyUrlHandlerConfig extends UrlHandlerConfig {
+
+  public static final int SITE_ROOT_LEVEL = 2;
+
+  @Override
+  public List<IntegratorMode> getIntegratorModes() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public boolean isSecure(Page page) {
+    return false;
+  }
+
+  @Override
+  public boolean isIntegrator(Page page) {
+    return false;
+  }
+
+  @Override
+  public int getSiteRootLevel(Resource contextResource) {
+    return SITE_ROOT_LEVEL;
+  }
+
+}

--- a/utils/src/test/resources/sitemap/sitemapservlet-sample.json
+++ b/utils/src/test/resources/sitemap/sitemapservlet-sample.json
@@ -46,6 +46,13 @@
             "jcr:primaryType": "cq:PageContent"
           }
         }
+      },
+      "fr": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:content": {
+          "jcr:primaryType": "cq:PageContent",
+          "jcr:language": "fr_FR"
+        }
       }
     }
   }

--- a/utils/src/test/resources/sitemap/sitemapservlet-sample.json
+++ b/utils/src/test/resources/sitemap/sitemapservlet-sample.json
@@ -1,0 +1,52 @@
+{
+  "foo": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent"
+    },
+    "en": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent"
+      },
+      "en": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:content": {
+          "jcr:primaryType": "cq:PageContent",
+          "cq:template": "/foo/template1",
+          "cq:lastModified": "2021-01-01T13:11:44.223-06:00",
+          "customExcludeProperty": false,
+          "customPriorityProperty": 0.75
+        },
+        "events": {
+          "jcr:primaryType": "cq:Page",
+          "jcr:content": {
+            "jcr:primaryType": "cq:PageContent",
+            "cq:template": "/foo/template2",
+            "customExcludeProperty": true,
+            "customPriorityProperty": 1.0
+          }
+        },
+        "about": {
+          "jcr:primaryType": "cq:Page",
+          "jcr:content": {
+            "jcr:primaryType": "cq:PageContent",
+            "cq:template": "/foo/template1"
+          }
+        }
+      },
+      "de": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:content": {
+          "jcr:primaryType": "cq:PageContent"
+        },
+        "events": {
+          "jcr:primaryType": "cq:Page",
+          "jcr:content": {
+            "jcr:primaryType": "cq:PageContent"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Configurable SiteMap Servlet, Work in Progress.

It provides enough functionallity to create a sitemap including /excluding configured pages. 

* Template ResourceType Homepage
* PageProperties for
  * exclude from sitemap
  * sitemap priority
* Excluded templates
* Excluded paths (regex)
 

I'm not 100% sure, how to deal with different languages though. In our project, we use /content/foo/COUNTRY/LANGUAGE as url schema. So we could simply iterate over all countries. 
Do you have any input how to detect other languages of the page in a more generic way?