### PR TITLE
Fixes wrong call to isNewArea in itemTemplate.html

### DIFF
--- a/parsys/changes.xml
+++ b/parsys/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.6.2" date="not released">
+      <action type="fix" dev="amuthmann">
+        Fix wrong call to isNewArea in itemTemplate.html.
+      </action>
+    </release>
+
     <release version="1.6.0" date="2021-01-17">
       <action type="update" dev="sseifert">
         Switch to AEM 6.4 as minimum version.

--- a/parsys/src/main/webapp/app-root/components/parsys/itemTemplate.html
+++ b/parsys/src/main/webapp/app-root/components/parsys/itemTemplate.html
@@ -2,17 +2,17 @@
 <template data-sly-template.renderItem="${@ item}">
 
   <!--/* Paragraph - with decoration */-->
-  <sly data-sly-test="${item.decorate && !item.newarea}"
+  <sly data-sly-test="${item.decorate && !item.newArea}"
       data-sly-resource="${item.resourcePath @ resourceType=item.resourceType,
       decorationTagName=item.elementName, cssClassName=item.cssClassName}"/>
 
   <!--/* Paragraph - without decoration */-->
-  <sly data-sly-test="${!item.decorate && !item.newarea}"
+  <sly data-sly-test="${!item.decorate && !item.newArea}"
       data-sly-resource="${item.resourcePath @ resourceType=item.resourceType,
       decoration=false}"/>
 
   <!--/* New area */-->
-  <div data-sly-test="${item.newarea}"
+  <div data-sly-test="${item.newArea}"
         style="${item.style @ context='unsafe'}"
         class="${item.cssClassName}"
         data-sly-element="${item.elementName}"


### PR DESCRIPTION
The getter for newArea is `isNewArea` but the sightly call `newarea`,  so the special handling for newArea Items is never triggered.

Props @fnack